### PR TITLE
fix(web): sass pass get-function to call instead of string

### DIFF
--- a/web/src/styles/abstracts/_functions.scss
+++ b/web/src/styles/abstracts/_functions.scss
@@ -278,7 +278,7 @@ Wisdom: https://sass-lang.com/documentation/at-rules/function
   $sum: 0;
 
   @for $index from $initial to $limit {
-    $sum: $sum + call($iteratee, $input, $index);
+    $sum: $sum + call(get-function($iteratee), $input, $index);
   }
 
   @return $sum;


### PR DESCRIPTION
Closes #18